### PR TITLE
chore: clean certificate-generator docker configuration

### DIFF
--- a/certificate-generator/Dockerfile
+++ b/certificate-generator/Dockerfile
@@ -1,9 +1,13 @@
-FROM alpine:3.11
+FROM golang:1 as mkcert
+RUN apt update \
+  && apt install -y git \
+  && rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/FiloSottile/mkcert \
+  && cd mkcert \
+  && go build -ldflags "-X main.Version=$(git describe --tags)"
 
-RUN wget -O /usr/local/bin/mkcert https://github.com/FiloSottile/mkcert/releases/download/v1.4.1/mkcert-v1.4.1-linux-amd64 \
-  && chmod +x /usr/local/bin/mkcert \
-  && mkdir /var/ssl
-
+FROM alpine:3
+RUN apk add --no-cache gcompat
+COPY --from=mkcert /go/mkcert/mkcert /usr/bin/mkcert
 COPY generate-certificates.sh /tools/generate-certificates.sh
-
 CMD ["/tools/generate-certificates.sh"]


### PR DESCRIPTION
this avoid to use direct link and use the recommended installation process 